### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/refuelking/templates/base.html
+++ b/refuelking/templates/base.html
@@ -2,14 +2,14 @@
 <html lang="de">
   <head>
     {% block head %}
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-    <meta name="description" lang="de" content="Refuelking findet die güstigste Tankstelle in Ihrer Nähe.">
-    <meta name="keywords" lang="de" content="Tankstelle, Tankerkönig, Zapfsäulenkönig, Diesel, Benzin, E10, E5, Auto, tanken">
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/>
+    <meta name="description" lang="de" content="Refuelking findet die güstigste Tankstelle in Ihrer Nähe."/>
+    <meta name="keywords" lang="de" content="Tankstelle, Tankerkönig, Zapfsäulenkönig, Diesel, Benzin, E10, E5, Auto, tanken"/>
     <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}" />
     <title>{% block title %}{% endblock %}</title>
-    <link rel="shortcut icon" href="{{ url_for('static', filename='img/gas_station_clipart_white.png') }}">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/gas_station_clipart_white.png') }}" sizes="32x32">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='img/gas_station_clipart_white.png') }}"/>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/gas_station_clipart_white.png') }}" sizes="32x32"/>
     {% endblock %}
   </head>
   <body>

--- a/refuelking/templates/index.html
+++ b/refuelking/templates/index.html
@@ -10,23 +10,23 @@ REFUELKING | Welche Tankstelle ist am günstigsten?
 <section id="title">
   <div class="container color-white">
     <div class="clear">
-      <img src="{{ url_for('static', filename='img/gas_station_clipart_white.png') }}">
+      <img src="{{ url_for('static', filename='img/gas_station_clipart_white.png') }}"/>
       <h1>Refuelking</h1>
     </div>
     <p>Finde die günstigste Tankstelle in deiner Nähe.</p>
     <form action="search">
-      <input type="text" name="address" value="Wilhelmstraße 129-133, 10963 Berlin">
+      <input type="text" name="address" value="Wilhelmstraße 129-133, 10963 Berlin"/>
        <select name="rad">
          <option value="1">1 km</option>
          <option value="3" selected>3 km</option>
          <option value="5">5 km</option>
          <option value="10">10 km</option>
        </select>
-      <input type="submit" value="Suche">
+      <input type="submit" value="Suche"/>
     </form>
     <div id="license">
       Verwendet wird die <strong><a href="http://www.tankerkoenig.de">Tankerkönig API</a></strong> unter der <strong><a href=" https://creativecommons.org/licenses/by/4.0/deed.de">CC BY 4.0</a></strong> Lizenz.
-      <!-- <br><em>Teile der API-Antworten werden in einer eigenen Datenbank zu Auswertungszwecken zwischengespeichert.</em> -->
+      <!-- <br/><em>Teile der API-Antworten werden in einer eigenen Datenbank zu Auswertungszwecken zwischengespeichert.</em> -->
     </div>
   </div>
 </section>

--- a/refuelking/templates/search.html
+++ b/refuelking/templates/search.html
@@ -2,7 +2,7 @@
 {% block head %}
     {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='search.css') }}" />
-    <link rel="stylesheet" href="http://openlayers.org/en/v3.16.0/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="http://openlayers.org/en/v3.16.0/css/ol.css" type="text/css"/>
     <script src="http://openlayers.org/en/v3.16.0/build/ol.js"></script>
 {% endblock %}
 {% block title %}Tankstellen in der Nähe{% endblock %}
@@ -20,15 +20,15 @@
         <table>
           <tr>
             <td>{{ "{:,.2f}".format(average_prices[0]) }}&euro;</td>
-            <td><img src="{{ url_for('static', filename='img/e10.png') }}" alt="E10"></td>
+            <td><img src="{{ url_for('static', filename='img/e10.png') }}" alt="E10"/></td>
           </tr>
           <tr>
             <td>{{ "{:,.2f}".format(average_prices[1]) }}&euro;</td>
-            <td><img src="{{ url_for('static', filename='img/e5.png') }}" alt="E5"></td>
+            <td><img src="{{ url_for('static', filename='img/e5.png') }}" alt="E5"/></td>
           </tr>
           <tr>
             <td>{{ "{:,.2f}".format(average_prices[2]) }}&euro;</td>
-            <td><img src="{{ url_for('static', filename='img/diesel.png') }}" alt="Diesel"></td>
+            <td><img src="{{ url_for('static', filename='img/diesel.png') }}" alt="Diesel"/></td>
           </tr>
         </table>
       </div>
@@ -38,15 +38,15 @@
         <table>
           <tr>
             <td>{{ best_time[0] }} Uhr</td>
-            <td><img src="{{ url_for('static', filename='img/e10.png') }}" alt="E10"></td>
+            <td><img src="{{ url_for('static', filename='img/e10.png') }}" alt="E10"/></td>
           </tr>
           <tr>
             <td>{{ best_time[1] }} Uhr</td>
-            <td><img src="{{ url_for('static', filename='img/e5.png') }}" alt="E5"></td>
+            <td><img src="{{ url_for('static', filename='img/e5.png') }}" alt="E5"/></td>
           </tr>
           <tr>
             <td>{{ best_time[2] }} Uhr</td>
-            <td><img src="{{ url_for('static', filename='img/diesel.png') }}" alt="Diesel"></td>
+            <td><img src="{{ url_for('static', filename='img/diesel.png') }}" alt="Diesel"/></td>
           </tr>
         </table>
       </div>
@@ -64,18 +64,18 @@
             <table>
               <tr>
                 <td>{{ station['e10'] }}&euro;</td>
-                <td><img src="{{ url_for('static', filename='img/e10.png') }}" alt="E10">{% if station['top_prices'][0] %} <img src="{{ url_for('static', filename='img/top.png') }}" alt="Günstigster Preis">{% endif %}</td>
+                <td><img src="{{ url_for('static', filename='img/e10.png') }}" alt="E10"/>{% if station['top_prices'][0] %} <img src="{{ url_for('static', filename='img/top.png') }}" alt="Günstigster Preis"/>{% endif %}</td>
               </tr>
               <tr>
                 <td>{{ station['e5'] }}&euro;</td>
-                <td><img src="{{ url_for('static', filename='img/e5.png') }}" alt="E5">{% if station['top_prices'][1] %} <img src="{{ url_for('static', filename='img/top.png') }}" alt="Günstigster Preis">{% endif %}</td>
+                <td><img src="{{ url_for('static', filename='img/e5.png') }}" alt="E5"/>{% if station['top_prices'][1] %} <img src="{{ url_for('static', filename='img/top.png') }}" alt="Günstigster Preis"/>{% endif %}</td>
               </tr>
               <tr>
                 <td>{{ station['diesel'] }}&euro;</td>
-                <td><img src="{{ url_for('static', filename='img/diesel.png') }}" alt="Diesel">{% if station['top_prices'][2] %} <img src="{{ url_for('static', filename='img/top.png') }}" alt="Günstigster Preis">{% endif %}</td>
+                <td><img src="{{ url_for('static', filename='img/diesel.png') }}" alt="Diesel"/>{% if station['top_prices'][2] %} <img src="{{ url_for('static', filename='img/top.png') }}" alt="Günstigster Preis"/>{% endif %}</td>
               </tr>
             </table>
-            <p>Entfernung: {{ station['dist'] }}km<br>{{ station['street']|lower }} {{ station['houseNumber']|lower }}, {{ station['postCode'] }} {{ station['place']|lower }}</p>
+            <p>Entfernung: {{ station['dist'] }}km<br/>{{ station['street']|lower }} {{ station['houseNumber']|lower }}, {{ station['postCode'] }} {{ station['place']|lower }}</p>
           </div>
         </a>
       {% endfor %}

--- a/refuelking/templates/station.html
+++ b/refuelking/templates/station.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% block head %}
     {{ super() }}
-    <link rel="stylesheet" href="http://openlayers.org/en/v3.16.0/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="http://openlayers.org/en/v3.16.0/css/ol.css" type="text/css"/>
     <script src="http://openlayers.org/en/v3.16.0/build/ol.js"></script>
-    <link href="http://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.css" rel="stylesheet" type="text/css">
+    <link href="http://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.css" rel="stylesheet" type="text/css"/>
     <script src="http://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.js"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='station.css') }}" />
     {{ price_plot[0]|safe }}
@@ -28,15 +28,15 @@
           <table class="price-table">
             <tr>
               <td>{{ station['e10'] }}&euro;</td>
-              <td><img src="{{ url_for('static', filename='img/e10.png') }}" alt="E10"></td>
+              <td><img src="{{ url_for('static', filename='img/e10.png') }}" alt="E10"/></td>
             </tr>
             <tr>
               <td>{{ station['e5'] }}&euro;</td>
-              <td><img src="{{ url_for('static', filename='img/e5.png') }}" alt="E5"></td>
+              <td><img src="{{ url_for('static', filename='img/e5.png') }}" alt="E5"/></td>
             </tr>
             <tr>
               <td>{{ station['diesel'] }}&euro;</td>
-              <td><img src="{{ url_for('static', filename='img/diesel.png') }}" alt="Diesel"></td>
+              <td><img src="{{ url_for('static', filename='img/diesel.png') }}" alt="Diesel"/></td>
             </tr>
         </table>
         </div>
@@ -50,7 +50,7 @@
 
           <p><strong>Hat derzeit {% if station['isOpen'] %}<span class="color-ok">geöffnet</span>{% else %}<span class="color-warning">geschlossen</span>{% endif %}.</strong></p>
           {% for time in station['openingTimes']: %}
-          <p>{{ time['text'] }}<br>{{ time['start'][:-3] }} - {{ time['end'][:-3] }}</p>
+          <p>{{ time['text'] }}<br/>{{ time['start'][:-3] }} - {{ time['end'][:-3] }}</p>
           {% endfor %}
         </div>
         <div class="box-element">


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tags anyhow - that is not an excuse for not writing specification valid code. And given the spirit of open-source community, I will be more than happy to push these improvements to you. The changes in this Pull-Request will not break your HTML code, and they have also been manually inspected, to ensure the only change is closing of void elements.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
